### PR TITLE
Add request logging and configurable port

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Small Express app that proxies requests to a given URL over HTTPS.
 
 ## Getting Started
 
-## Configuration
+### Configuration
 
 The proxy server can be configured using environment variables. These can be set inline or added to a `.env` file in the project root.
 
 - `PROXY_URL`: the destination URL (required)
 - `PORT`: Port to run the server on (optional; defaults to `3000`)
 
-## Scripts
+### Scripts
 
-### `npm start`
+#### `npm start`
 
 Starts the proxy server.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 Small Express app that proxies requests to a given URL over HTTPS.
 
+## Getting Started
+
+## Configuration
+
+The proxy server can be configured using environment variables. These can be set inline or added to a `.env` file in the project root.
+
+- `PROXY_URL`: the destination URL (required)
+- `PORT`: Port to run the server on (optional; defaults to `3000`)
+
 ## Scripts
 
 ### `npm start`
 
 Starts the proxy server.
-
-## Environment variables
-
-Environment variables can be set inline or added to a `.env` file in the project root.
-
-- `PROXY_URL`: the destination URL

--- a/index.js
+++ b/index.js
@@ -1,11 +1,21 @@
-var proxy = require('express-http-proxy');
-var cors = require('cors');
-var app = require('express')();
 require('dotenv').config();
 
+const proxy = require('express-http-proxy');
+const cors = require('cors');
+const morgan = require('morgan');
+const app = require('express')();
+
+const port = process.env.PORT || 3000;
+const proxyUrl = process.env.PROXY_URL;
+
+if (!proxyUrl) {
+  console.error(`No proxy URL is configured, make sure the PROXY_URL environment variable is set.`);
+  process.exit(1);
+}
+
+app.use(morgan('dev'));
 app.use(cors());
 app.use('/', proxy(process.env.PROXY_URL, { https: true }));
-app.listen(3000, () => {
-  console.log('Proxy server listening on port 3000')
+app.listen(port, () => {
+  console.log(`Proxy server listening on port ${port}`)
 });
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,14 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -327,6 +335,38 @@
         "mime-db": "1.44.0"
       }
     },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -349,6 +389,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "parseurl": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "express-http-proxy": "^1.6.0"
+    "express-http-proxy": "^1.6.0",
+    "morgan": "^1.10.0"
   }
 }


### PR DESCRIPTION
This PR adds basic request logging using [morgan](https://github.com/expressjs/morgan). It also addresses a couple minor details such as making the port configurable and logging a descriptive error if a proxy URL was not configured.